### PR TITLE
Add qurt support to cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,11 +200,7 @@ px4_common_modules()
 #=============================================================================
 #	Build
 
-set(installed_targets)
-
 px4_target_firmware()
-
-list(APPEND installed_targets main)
 
 #=============================================================================
 #	Install

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ posix-sitl_simple:
 		-DOS=posix -DBOARD=sitl -DLABEL=simple && \
 		make && ctest -V && cpack -G ZIP
 
+qurt-hil_simple:
+	mkdir -p $d/build_$@ && cd $d/build_$@ && \
+		cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-hexagon.cmake \
+		-DOS=qurt -DBOARD=hil -DLABEL=simple && \
+		make && ctest -V && cpack -G ZIP
+
 clean:
 	rm -rf build_*/
 

--- a/cmake/Toolchain-hexagon.cmake
+++ b/cmake/Toolchain-hexagon.cmake
@@ -1,0 +1,249 @@
+#
+# Copyright (C) 2015 Mark Charlebois. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#	notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#	notice, this list of conditions and the following disclaimer in
+#	the documentation and/or other materials provided with the
+#	distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#	used to endorse or promote products derived from this software
+#	without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+include(CMakeForceCompiler)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(px4_utils)
+
+if(NOT HEXAGON_TOOLS_ROOT)
+	set(HEXAGON_TOOLS_ROOT /opt/6.4.05)
+endif()
+
+if(NOT HEXAGON_SDK_ROOT)
+	set(HEXAGON_SDK_ROOT /opt/Hexagon_SDK)
+endif()
+
+macro (list2string out in)
+	set(list ${ARGV})
+	list(REMOVE_ITEM list ${out})
+	foreach(item ${list})
+		set(${out} "${${out}} ${item}")
+	endforeach()
+endmacro(list2string)
+
+set(V_ARCH "v5")
+set(CROSSDEV "hexagon-")
+set(HEXAGON_BIN	${HEXAGON_TOOLS_ROOT}/gnu/bin)
+set(HEXAGON_CLANG_BIN ${HEXAGON_TOOLS_ROOT}/qc/bin)
+set(HEXAGON_LIB_DIR ${HEXAGON_TOOLS_ROOT}/gnu/hexagon/lib)
+set(HEXAGON_ISS_DIR ${HEXAGON_TOOLS_ROOT}/qc/lib/iss)
+set(TOOLSLIB ${HEXAGON_TOOLS_ROOT}/dinkumware/lib/$(V_ARCH)/G0)
+set(QCTOOLSLIB ${HEXAGON_TOOLS_ROOT}/qc/lib/$(V_ARCH)/G0)
+
+# Use the HexagonTools compiler (6.4.05)
+set(CMAKE_C_COMPILER	${HEXAGON_CLANG_BIN}/${CROSSDEV}clang)
+set(CMAKE_CXX_COMPILER  ${HEXAGON_CLANG_BIN}/${CROSSDEV}clang++)
+
+set(CMAKE_AR	  ${HEXAGON_BIN}/${CROSSDEV}ar CACHE FILEPATH "Archiver")
+set(CMAKE_RANLIB  ${HEXAGON_BIN}/${CROSSDEV}ranlib)
+set(CMAKE_LINKER  ${HEXAGON_BIN}/${CROSSDEV}ld)
+set(CMAKE_NM	  ${HEXAGON_BIN}/${CROSSDEV}nm)
+set(CMAKE_OBJDUMP ${HEXAGON_BIN}/${CROSSDEV}objdump)
+set(CMAKE_OBJCOPY ${HEXAGON_BIN}/${CROSSDEV}objcopy)
+
+list2string(HEXAGON_INCLUDE_DIRS 
+	-I${HEXAGON_TOOLS_ROOT}/gnu/hexagon/include
+	-I${HEXAGON_SDK_ROOT}/inc
+	-I${HEXAGON_SDK_ROOT}/inc/stddef
+	)
+
+#set(DYNAMIC_LIBS  -Wl,${TOOLSLIB}/pic/libstdc++.a)
+
+#set(MAXOPTIMIZATION -O0)
+
+# Base CPU flags for each of the supported architectures.
+#
+set(ARCHCPUFLAGS
+	-m${V_ARCH}
+	-G0
+	)
+
+add_definitions(
+	-D_PID_T -D_UID_T -D_TIMER_T
+	-Dnoreturn_function= 
+	-D__EXPORT= 
+	-Drestrict=
+	-D_DEBUG
+	-Wno-error=shadow
+	)
+
+# optimisation flags
+#
+set(ARCHOPTIMIZATION
+	-O0
+	-g
+	-fno-strict-aliasing
+	-fdata-sections
+	-fpic
+	-fno-zero-initialized-in-bss
+	)
+
+# Language-specific flags
+#
+set(ARCHCFLAGS
+	-std=gnu99
+	-D__CUSTOM_FILE_IO__
+	)
+set(ARCHCXXFLAGS
+	-fno-exceptions
+	-fno-rtti
+	-std=c++11
+	-fno-threadsafe-statics
+	-DCONFIG_WCHAR_BUILTIN
+	-D__CUSTOM_FILE_IO__
+	)
+
+set(ARCHWARNINGS
+	-Wall
+	-Wextra
+	-Werror
+	-Wno-unused-parameter
+	-Wno-unused-function
+	-Wno-unused-variable
+	-Wno-gnu-array-member-paren-init
+	-Wno-cast-align
+	-Wno-missing-braces
+	-Wno-strict-aliasing
+#   -Werror=float-conversion - works, just needs to be phased in with some effort and needs GCC 4.9+
+#   -Wcast-qual  - generates spurious noreturn attribute warnings, try again later
+#   -Wconversion - would be nice, but too many "risky-but-safe" conversions in the code
+#   -Wcast-align - would help catch bad casts in some cases, but generates too many false positives
+	)
+
+# C-specific warnings
+#
+set(ARCHCWARNINGS
+	${ARCHWARNINGS}
+	-Wstrict-prototypes
+	-Wnested-externs
+	)
+
+# C++-specific warnings
+#
+set(ARCHWARNINGSXX
+	${ARCHWARNINGS}
+	-Wno-missing-field-initializers
+	)
+exec_program(${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR} ARGS -print-libgcc-file-name OUTPUT_VARIABLE LIBGCC)
+exec_program(${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR} ARGS -print-file-name=libm.a OUTPUT_VARIABLE LIBM)
+set(EXTRA_LIBS ${EXTRA_LIBS} ${LIBM})
+
+# Flags we pass to the C compiler
+#
+list2string(CFLAGS 
+	${ARCHCFLAGS}
+	${ARCHCWARNINGS}
+	${ARCHOPTIMIZATION}
+	${ARCHCPUFLAGS}
+	${ARCHINCLUDES}
+	${INSTRUMENTATIONDEFINES}
+	${ARCHDEFINES}
+	${EXTRADEFINES}
+	${EXTRACFLAGS}
+	${HEXAGON_INCLUDE_DIRS}
+	)
+
+# Flags we pass to the C++ compiler
+#
+list2string(CXXFLAGS
+	${ARCHCXXFLAGS}
+	${ARCHWARNINGSXX}
+	${ARCHOPTIMIZATION}
+	${ARCHCPUFLAGS}
+	${ARCHXXINCLUDES}
+	${INSTRUMENTATIONDEFINES}
+	${ARCHDEFINES}
+	${EXTRADEFINES}
+	${EXTRACXXFLAGS}
+	${HEXAGON_INCLUDE_DIRS}
+	)
+
+# Flags we pass to the assembler
+#
+list2string(AFLAGS
+	${CFLAGS} 
+	-D__ASSEMBLY__
+	${EXTRADEFINES}
+	${EXTRAAFLAGS}
+	)
+
+# Set cmake flags
+#
+list2string(CMAKE_C_FLAGS
+	${CMAKE_C_FLAGS}
+	${CFLAGS}
+	)
+
+set(QURT_CMAKE_C_FLAGS ${CMAKE_C_FLAGS} CACHE STRING "cflags")
+
+message(STATUS "CMAKE_C_FLAGS: -${CMAKE_C_FLAGS}-")
+
+list2string(CMAKE_CXX_FLAGS
+	${CMAKE_CXX_FLAGS}
+	${CXXFLAGS}
+	)
+
+set(QURT_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "cxxflags")
+
+message(STATUS "CMAKE_CXX_FLAGS: -${CMAKE_CXX_FLAGS}-")
+
+# Flags we pass to the linker
+#
+list2string(CMAKE_EXE_LINKER_FLAGS
+	-g 
+	-mv5 
+	-mG0lib 
+	-G0 
+	-fpic 
+	-shared
+	-Wl,-Bsymbolic
+	-Wl,--wrap=malloc
+	-Wl,--wrap=calloc
+	-Wl,--wrap=free
+	-Wl,--wrap=realloc
+	-Wl,--wrap=memalign
+	-Wl,--wrap=__stack_chk_fail
+	-lc
+	${EXTRALDFLAGS}
+	)
+
+# where is the target environment 
+set(CMAKE_FIND_ROOT_PATH  get_file_component(${C_COMPILER} PATH))
+
+set(CMAKE_C_COMPILER_ID, "Clang")
+set(CMAKE_CXX_COMPILER_ID, "Clang")
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/common/px4_common.cmake
+++ b/cmake/common/px4_common.cmake
@@ -66,22 +66,17 @@ macro(px4_common_set_flags)
 		-Wall
 		-Wno-sign-compare
 		-Wextra
-		-Wdouble-promotion
 		-Wshadow
 		-Wfloat-equal
 		-Wframe-larger-than=1024
 		-Wpointer-arith
-		-Wlogical-op
 		-Wmissing-declarations
 		-Wpacked
 		-Wno-unused-parameter
 		-Werror=format-security
 		-Werror=array-bounds
 		-Wfatal-errors
-		-Wformat=1
-		-Werror=unused-but-set-variable
 		-Werror=unused-variable
-		-Werror=double-promotion
 		-Werror=reorder
 		-Werror=uninitialized
 		-Werror=init-self 
@@ -93,18 +88,32 @@ macro(px4_common_set_flags)
 		#               but generates too many false positives
 		)
 
+	if (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+		set(WARNINGS ${WARNINGS}
+			-Werror=unused-but-set-variable
+			-Wformat=1
+			-Wlogical-op
+			-Wdouble-promotion
+			-Werror=double-promotion
+		)
+	endif()
+	
 
 	set(MAX_OPTIMIZATION -Os)
 
 	set(OPTIMIZATION_FLAGS
 		-fno-strict-aliasing
-		-fno-strength-reduce
 		-fomit-frame-pointer
 		-funsafe-math-optimizations
-		-fno-builtin-printf
 		-ffunction-sections
 		-fdata-sections
 		)
+	if (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+		set(OPTIMIZATION_FLAGS ${OPTIMIZATION_FLAGS}
+			-fno-strength-reduce
+			-fno-builtin-printf
+		)
+	endif()
 
 	#=============================================================================
 	#		c flags
@@ -112,11 +121,17 @@ macro(px4_common_set_flags)
 	set(C_WARNINGS
 		-Wbad-function-cast
 		-Wstrict-prototypes
-		-Wold-style-declaration
-		-Wmissing-parameter-type
 		-Wmissing-prototypes
 		-Wnested-externs
 		)
+
+	if (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+		set(C_WARNINGS ${C_WARNINGS}
+			-Wold-style-declaration
+			-Wmissing-parameter-type
+		)
+	endif()
+
 	set(C_FLAGS
 		-std=gnu99
 		-fno-common
@@ -303,6 +318,5 @@ macro(px4_common_git_submodules)
 	add_git_submodule(genmsg Tools/genmsg)
 	add_git_submodule(gencpp Tools/gencpp)
 	add_git_submodule(gtest unittests/gtest)
-	add_git_submodule(eigen src/lib/eigen) 
 endmacro()
 

--- a/cmake/nuttx/px4_target_impl.cmake
+++ b/cmake/nuttx/px4_target_impl.cmake
@@ -51,6 +51,8 @@ set(nuttx_configs px4fmu-v2)
 
 set(NUTTX_EXPORT_DIR ${CMAKE_BINARY_DIR}/${BOARD}/NuttX/nuttx-export)
 
+add_git_submodule(eigen src/lib/eigen)
+
 macro(px4_target_set_flags)
 	include_directories(
 		${NUTTX_EXPORT_DIR}/include
@@ -115,6 +117,7 @@ macro(px4_target_validate_config)
 endmacro()
 
 macro(px4_target_firmware)
+	set(installed_targets)
 	message(STATUS "modules: ${module_list}")
 	link_directories(${NUTTX_EXPORT_DIR}/libs)
 
@@ -164,6 +167,7 @@ macro(px4_target_firmware)
 		set_target_properties(main PROPERTIES LINK_FLAGS ${MAIN_LINK_FLAGS})
 		generate_firmware(${TARGET_NAME})
 	endif()
+	list(APPEND installed_targets main)
 endmacro()
 
 macro(px4_target_rules)

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -41,7 +41,7 @@
 #include <px4_config.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <poll.h>
+#include <px4_posix.h>
 #include <string.h>
 
 #include <uORB/uORB.h>
@@ -64,7 +64,7 @@ int px4_simple_app_main(int argc, char *argv[])
 	orb_advert_t att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
 
 	/* one could wait for multiple topics with this technique, just using one here */
-	struct pollfd fds[] = {
+	px4_pollfd_struct_t fds[] = {
 		{ .fd = sensor_sub_fd,   .events = POLLIN },
 		/* there could be more file descriptors here, in the form like:
 		 * { .fd = other_sub_fd,   .events = POLLIN },
@@ -75,7 +75,7 @@ int px4_simple_app_main(int argc, char *argv[])
 
 	for (int i = 0; i < 5; i++) {
 		/* wait for sensor update of 1 file descriptor for 1000 ms (1 second) */
-		int poll_ret = poll(fds, 1, 1000);
+		int poll_ret = px4_poll(fds, 1, 1000);
 
 		/* handle the poll result */
 		if (poll_ret == 0) {

--- a/src/modules/systemlib/CMakeLists.txt
+++ b/src/modules/systemlib/CMakeLists.txt
@@ -27,7 +27,7 @@ if (${OS} STREQUAL "nuttx")
 		up_cxxinitialize.c
 		)
 
-elseif (${OS} STREQUAL "qurt")
+elseif (NOT ${OS} STREQUAL "qurt")
 	list(APPEND SRCS
 		hx_stream.c
 		)

--- a/src/modules/systemlib/perf_counter.c
+++ b/src/modules/systemlib/perf_counter.c
@@ -47,6 +47,9 @@
 
 #ifdef __PX4_QURT
 #define dprintf(...) 
+#define ddeclare(...) 
+#else
+#define ddeclare(...) __VA_ARGS__
 #endif
 
 /**
@@ -394,8 +397,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 		break;
 
 	case PC_ELAPSED: {
-		struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
-		float rms = sqrtf(pce->M2 / (pce->event_count-1));
+		ddeclare(struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;)
+		ddeclare(float rms = sqrtf(pce->M2 / (pce->event_count-1));)
 
 		dprintf(fd, "%s: %llu events, %llu overruns, %lluus elapsed, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 			handle->name,
@@ -410,8 +413,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 	}
 
 	case PC_INTERVAL: {
-		struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
-		float rms = sqrtf(pci->M2 / (pci->event_count-1));
+		ddeclare(struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;)
+		ddeclare(float rms = sqrtf(pci->M2 / (pci->event_count-1));)
 
 		dprintf(fd, "%s: %llu events, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 			handle->name,

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -70,33 +70,33 @@ static inline void do_nothing(int level, ...)
 /****************************************************************************
  * Messages that should never be filtered or compiled out
  ****************************************************************************/
-#define PX4_LOG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_INFO(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_LOG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_INFO(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #if defined(TRACE_BUILD)
 /****************************************************************************
  * Extremely Verbose settings for a Trace build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #elif defined(DEBUG_BUILD)
 /****************************************************************************
  * Verbose settings for a Debug build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN, __FILENAME__, __LINE__,  FMT, ##__VA_ARGS__)
-#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN, __FILE__, __LINE__,  FMT, ##__VA_ARGS__)
+#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #elif defined(RELEASE_BUILD)
 /****************************************************************************
  * Non-verbose settings for a Release build to minimize strings in build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 #define PX4_WARN(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_WARN, FMT, ##__VA_ARGS__)
 #define PX4_DEBUG(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_DEBUG, FMT, ##__VA_ARGS__)
 
@@ -104,14 +104,14 @@ static inline void do_nothing(int level, ...)
 /****************************************************************************
  * Medium verbose settings for a default build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 #define PX4_DEBUG(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_DEBUG, FMT, ##__VA_ARGS__)
 
 #endif
-#define PX4_LOG_NAMED(name, FMT, ...) 	qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, "%s " FMT, name, ##__VA_ARGS__)
-#define PX4_LOG_NAMED_COND(name, cond, FMT, ...) if( cond ) qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, "%s " FMT, name,  ##__VA_ARGS__)
+#define PX4_LOG_NAMED(name, FMT, ...) 	qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, "%s " FMT, name, ##__VA_ARGS__)
+#define PX4_LOG_NAMED_COND(name, cond, FMT, ...) if( cond ) qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, "%s " FMT, name,  ##__VA_ARGS__)
 
 #else
 

--- a/src/platforms/qurt/px4_layer/main.cpp
+++ b/src/platforms/qurt/px4_layer/main.cpp
@@ -94,7 +94,6 @@ static void process_commands(map<string,px4_main_t> &apps, const char *cmds)
 	vector<string> appargs;
 	int i=0;
 	const char *b = cmds;
-	bool found_first_char = false;
 	char arg[256];
 
 	// This is added because it is a parameter used by commander, yet created by mavlink.  Since mavlink is not


### PR DESCRIPTION
Made additional fixes found by clang while enabling the qurt build.

Unused variables in perf_counter.c and main.cpp were fixed.

Use of poll vs px4_poll was fixed in px4_simple_app.c

Signed-off-by: Mark Charlebois charlebm@gmail.com
