### PR TITLE
Fixed empty cmake set commands

### DIFF
--- a/cmake/fix_empty_set_cmd.py
+++ b/cmake/fix_empty_set_cmd.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os
+import re
+
+data = open(os.sys.argv[1], 'r').read()
+newdata = re.sub(r"^set(.*)$\n\t\)",r"set\1)" , data, flags=re.MULTILINE)
+
+open(os.sys.argv[1], "w").write(newdata)

--- a/src/drivers/airspeed/CMakeLists.txt
+++ b/src/drivers/airspeed/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	airspeed.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/ardrone_interface/CMakeLists.txt
+++ b/src/drivers/ardrone_interface/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main ardrone_interface)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	ardrone_interface.c
 	ardrone_motor_control.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/batt_smbus/CMakeLists.txt
+++ b/src/drivers/batt_smbus/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main batt_smbus)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	batt_smbus.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/blinkm/CMakeLists.txt
+++ b/src/drivers/blinkm/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main blinkm)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	blinkm.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/bma180/CMakeLists.txt
+++ b/src/drivers/bma180/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main bma180)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	bma180.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/aerocore/CMakeLists.txt
+++ b/src/drivers/boards/aerocore/CMakeLists.txt
@@ -35,16 +35,13 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	aerocore_init.c
 	aerocore_pwm_servo.c
 	aerocore_spi.c
 	aerocore_led.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/px4-stm32f4discovery/CMakeLists.txt
+++ b/src/drivers/boards/px4-stm32f4discovery/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4discovery_init.c
 	px4discovery_usb.c
 	px4discovery_led.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/px4fmu-v1/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v1/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4fmu_can.c
 	px4fmu_init.c
@@ -47,6 +45,5 @@ set(srcs
 	px4fmu_usb.c
 	px4fmu_led.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/px4fmu-v2/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v2/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4fmu_can.c
 	px4fmu2_init.c
@@ -47,6 +45,5 @@ set(srcs
 	px4fmu_usb.c
 	px4fmu2_led.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/px4io-v1/CMakeLists.txt
+++ b/src/drivers/boards/px4io-v1/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4io_init.c
 	px4io_pwm_servo.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/boards/px4io-v2/CMakeLists.txt
+++ b/src/drivers/boards/px4io-v2/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4iov2_init.c
 	px4iov2_pwm_servo.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/camera_trigger/CMakeLists.txt
+++ b/src/drivers/camera_trigger/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main camera_trigger)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	camera_trigger.cpp
 	camera_trigger_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/device/CMakeLists.txt
+++ b/src/drivers/device/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	device_nuttx.cpp
 	cdev.cpp
@@ -47,6 +45,5 @@ set(srcs
 	spi.cpp
 	ringbuffer.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/ets_airspeed/CMakeLists.txt
+++ b/src/drivers/ets_airspeed/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main ets_airspeed)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	ets_airspeed.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/frsky_telemetry/CMakeLists.txt
+++ b/src/drivers/frsky_telemetry/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main frsky_telemetry)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	frsky_data.c
 	frsky_telemetry.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/gimbal/CMakeLists.txt
+++ b/src/drivers/gimbal/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main gimbal)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	gimbal.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main gps)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	gps.cpp
 	gps_helper.cpp
@@ -46,6 +44,5 @@ set(srcs
 	ashtech.cpp
 	ubx.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/hmc5883/CMakeLists.txt
+++ b/src/drivers/hmc5883/CMakeLists.txt
@@ -38,13 +38,11 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	hmc5883_i2c.cpp
 	hmc5883_spi.cpp
 	hmc5883.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/hott/CMakeLists.txt
+++ b/src/drivers/hott/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	messages.cpp
 	comms.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/hott/hott_sensors/CMakeLists.txt
+++ b/src/drivers/hott/hott_sensors/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main hott_sensors)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hott_sensors.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/hott/hott_telemetry/CMakeLists.txt
+++ b/src/drivers/hott/hott_telemetry/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main hott_telemetry)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hott_telemetry.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/irlock/CMakeLists.txt
+++ b/src/drivers/irlock/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main irlock)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	irlock.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/l3gd20/CMakeLists.txt
+++ b/src/drivers/l3gd20/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	l3gd20.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/led/CMakeLists.txt
+++ b/src/drivers/led/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	led.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/ll40ls/CMakeLists.txt
+++ b/src/drivers/ll40ls/CMakeLists.txt
@@ -35,16 +35,13 @@ set(main ll40ls)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	ll40ls.cpp
 	LidarLite.cpp
 	LidarLiteI2C.cpp
 	LidarLitePWM.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/lsm303d/CMakeLists.txt
+++ b/src/drivers/lsm303d/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	lsm303d.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/mb12xx/CMakeLists.txt
+++ b/src/drivers/mb12xx/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main mb12xx)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mb12xx.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/md25/CMakeLists.txt
+++ b/src/drivers/md25/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main md25)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	md25.cpp
 	md25_main.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/meas_airspeed/CMakeLists.txt
+++ b/src/drivers/meas_airspeed/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	meas_airspeed.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/mkblctrl/CMakeLists.txt
+++ b/src/drivers/mkblctrl/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main mkblctrl)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mkblctrl.cpp
 	mkblctrl_params.c

--- a/src/drivers/mpu6000/CMakeLists.txt
+++ b/src/drivers/mpu6000/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	mpu6000.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/mpu9250/CMakeLists.txt
+++ b/src/drivers/mpu9250/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	mpu9250.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/ms5611/CMakeLists.txt
+++ b/src/drivers/ms5611/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main ms5611)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	ms5611_nuttx.cpp
 	ms5611_spi.cpp
 	ms5611_i2c.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/oreoled/CMakeLists.txt
+++ b/src/drivers/oreoled/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main oreoled)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	oreoled.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/pca8574/CMakeLists.txt
+++ b/src/drivers/pca8574/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main pca8574)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	pca8574.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/pca9685/CMakeLists.txt
+++ b/src/drivers/pca9685/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main pca9685)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	pca9685.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/pwm_input/CMakeLists.txt
+++ b/src/drivers/pwm_input/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization)
 set(extra_cxxflags
 	-Wno-pmf-conversions
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	pwm_input.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/pwm_out_sim/CMakeLists.txt
+++ b/src/drivers/pwm_out_sim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main pwm_out_sim)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	pwm_out_sim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/px4flow/CMakeLists.txt
+++ b/src/drivers/px4flow/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wno-attributes
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	px4flow.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/px4fmu/CMakeLists.txt
+++ b/src/drivers/px4fmu/CMakeLists.txt
@@ -38,12 +38,10 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	fmu.cpp
 	px4fmu_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	px4io.cpp
 	px4io_uploader.cpp

--- a/src/drivers/rgbled/CMakeLists.txt
+++ b/src/drivers/rgbled/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main rgbled)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	rgbled.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/roboclaw/CMakeLists.txt
+++ b/src/drivers/roboclaw/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main roboclaw)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	roboclaw_main.cpp
 	RoboClaw.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/sf0x/CMakeLists.txt
+++ b/src/drivers/sf0x/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main sf0x)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	sf0x.cpp
 	sf0x_parser.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/drivers/stm32/CMakeLists.txt
+++ b/src/drivers/stm32/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	drv_hrt.c
 	drv_pwm_servo.c

--- a/src/drivers/stm32/adc/CMakeLists.txt
+++ b/src/drivers/stm32/adc/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main adc)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	adc.cpp
 	)

--- a/src/drivers/stm32/tone_alarm/CMakeLists.txt
+++ b/src/drivers/stm32/tone_alarm/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main tone_alarm)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	tone_alarm.cpp
 	)

--- a/src/drivers/trone/CMakeLists.txt
+++ b/src/drivers/trone/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main trone)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	trone.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/fixedwing_control/CMakeLists.txt
+++ b/src/examples/fixedwing_control/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main ex_fixedwing_control)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wframe-larger-than=1300
 	)
@@ -44,6 +43,5 @@ set(srcs
 	main.c
 	params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/flow_position_estimator/CMakeLists.txt
+++ b/src/examples/flow_position_estimator/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main flow_position_estimator)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wno-float-equal
 	)
@@ -44,6 +43,5 @@ set(srcs
 	flow_position_estimator_main.c
 	flow_position_estimator_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/hwtest/CMakeLists.txt
+++ b/src/examples/hwtest/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main ex_hwtest)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hwtest.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/matlab_csv_serial/CMakeLists.txt
+++ b/src/examples/matlab_csv_serial/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main matlab_csv_serial)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	matlab_csv_serial.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/publisher/CMakeLists.txt
+++ b/src/examples/publisher/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main publisher)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	publisher_main.cpp
 	publisher_start_nuttx.cpp
 	publisher_example.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/px4_daemon_app/CMakeLists.txt
+++ b/src/examples/px4_daemon_app/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main px4_daemon_app)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_daemon_app.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/px4_mavlink_debug/CMakeLists.txt
+++ b/src/examples/px4_mavlink_debug/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main px4_mavlink_debug)
 set(priority)
 set(stack_size 2000)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_mavlink_debug.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/px4_simple_app/CMakeLists.txt
+++ b/src/examples/px4_simple_app/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main px4_simple_app)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_simple_app.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/rover_steering_control/CMakeLists.txt
+++ b/src/examples/rover_steering_control/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main rover_steering_control)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wframe-larger-than=1300
 	)
@@ -44,6 +43,5 @@ set(srcs
 	main.cpp
 	params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/examples/subscriber/CMakeLists.txt
+++ b/src/examples/subscriber/CMakeLists.txt
@@ -35,16 +35,13 @@ set(main subscriber)
 set(priority)
 set(stack_size 2400)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	subscriber_main.cpp
 	subscriber_start_nuttx.cpp
 	subscriber_example.cpp
 	subscriber_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/conversion/CMakeLists.txt
+++ b/src/lib/conversion/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	rotation.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/ecl/CMakeLists.txt
+++ b/src/lib/ecl/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	attitude_fw/ecl_controller.cpp
 	attitude_fw/ecl_pitch_controller.cpp
@@ -46,6 +44,5 @@ set(srcs
 	attitude_fw/ecl_yaw_controller.cpp
 	l1/ecl_l1_pos_controller.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/external_lgpl/CMakeLists.txt
+++ b/src/lib/external_lgpl/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	tecs/tecs.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/geo/CMakeLists.txt
+++ b/src/lib/geo/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	geo.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/geo_lookup/CMakeLists.txt
+++ b/src/lib/geo_lookup/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	geo_mag_declination.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/launchdetection/CMakeLists.txt
+++ b/src/lib/launchdetection/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	LaunchDetector.cpp
 	CatapultLaunchMethod.cpp
 	launchdetection_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	math/test/test.cpp
 	math/Limits.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/mathlib/math/filter/CMakeLists.txt
+++ b/src/lib/mathlib/math/filter/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	LowPassFilter2p.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	st24.c
 	sumd.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/attitude_estimator_ekf/CMakeLists.txt
+++ b/src/modules/attitude_estimator_ekf/CMakeLists.txt
@@ -46,6 +46,5 @@ set(srcs
 	attitude_estimator_ekf_params.c
 	codegen/AttitudeEKF.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/attitude_estimator_q/CMakeLists.txt
+++ b/src/modules/attitude_estimator_q/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main attitude_estimator_q)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	attitude_estimator_q_main.cpp
 	attitude_estimator_q_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/bottle_drop/CMakeLists.txt
+++ b/src/modules/bottle_drop/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main bottle_drop)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	bottle_drop.cpp
 	bottle_drop_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wframe-larger-than=2200
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	commander.cpp
 	commander_params.c
@@ -55,6 +54,5 @@ set(srcs
 	esc_calibration.cpp
 	PreflightCheck.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/commander/commander_tests/CMakeLists.txt
+++ b/src/modules/commander/commander_tests/CMakeLists.txt
@@ -35,16 +35,13 @@ set(main commander_tests)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	commander_tests.cpp
 	state_machine_helper_test.cpp
 	../state_machine_helper.cpp
 	../PreflightCheck.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/controllib/CMakeLists.txt
+++ b/src/modules/controllib/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	test_params.c
 	block/Block.cpp
@@ -46,6 +44,5 @@ set(srcs
 	uorb/blocks.cpp
 	blocks.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/dataman/CMakeLists.txt
+++ b/src/modules/dataman/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main dataman)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	dataman.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/ekf_att_pos_estimator/CMakeLists.txt
+++ b/src/modules/ekf_att_pos_estimator/CMakeLists.txt
@@ -39,14 +39,12 @@ set(extra_cxxflags
 	-Weffc++
 	-Wframe-larger-than=3400
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	ekf_att_pos_estimator_main.cpp
 	ekf_att_pos_estimator_params.c
 	estimator_22states.cpp
 	estimator_utilities.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/fixedwing_backside/CMakeLists.txt
+++ b/src/modules/fixedwing_backside/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main fixedwing_backside)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	fixedwing_backside_main.cpp
 	fixedwing.cpp
 	params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/fw_att_control/CMakeLists.txt
+++ b/src/modules/fw_att_control/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main fw_att_control)
 set(priority)
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	fw_att_control_main.cpp
 	fw_att_control_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/fw_pos_control_l1/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wno-float-equal
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	fw_pos_control_l1_main.cpp
 	fw_pos_control_l1_params.c
@@ -48,6 +47,5 @@ set(srcs
 	mtecs/limitoverride.cpp
 	mtecs/mTecs_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/gpio_led/CMakeLists.txt
+++ b/src/modules/gpio_led/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main gpio_led)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	gpio_led.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/land_detector/CMakeLists.txt
+++ b/src/modules/land_detector/CMakeLists.txt
@@ -39,8 +39,7 @@ set(extra_cxxflags
 	-Weffc++
 	-Os
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	land_detector_main.cpp
 	land_detector_params.c
@@ -48,6 +47,5 @@ set(srcs
 	MulticopterLandDetector.cpp
 	FixedwingLandDetector.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -44,8 +44,7 @@ set(extra_cxxflags
 set(extra_cflags
 	-Wno-packed
 	)
-set(srcs
-	)
+set(srcs)
 set(includes
 	${MAVLINK_SRC}/include/mavlink
 	)

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main mc_att_control)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mc_att_control_main.cpp
 	mc_att_control_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/mc_att_control_multiplatform/CMakeLists.txt
+++ b/src/modules/mc_att_control_multiplatform/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main mc_att_control_m)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mc_att_control_main.cpp
 	mc_att_control_start_nuttx.cpp
@@ -46,6 +44,5 @@ set(srcs
 	mc_att_control_base.cpp
 	mc_att_control_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main mc_pos_control)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mc_pos_control_main.cpp
 	mc_pos_control_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/mc_pos_control_multiplatform/CMakeLists.txt
+++ b/src/modules/mc_pos_control_multiplatform/CMakeLists.txt
@@ -38,14 +38,12 @@ set(max_optimization)
 set(extra_cxxflags
 	-Wframe-larger-than=1200
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	mc_pos_control_main.cpp
 	mc_pos_control_start_nuttx.cpp
 	mc_pos_control.cpp
 	mc_pos_control_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/muorb/adsp/CMakeLists.txt
+++ b/src/modules/muorb/adsp/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4muorb.cpp
 	uORBFastRpcChannel.cpp

--- a/src/modules/muorb/krait/CMakeLists.txt
+++ b/src/modules/muorb/krait/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main muorb)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	uORBKraitFastRpcChannel.cpp
 	muorb_main.cpp

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wno-sign-compare
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	navigator_main.cpp
 	navigator_params.c

--- a/src/modules/position_estimator_inav/CMakeLists.txt
+++ b/src/modules/position_estimator_inav/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main position_estimator_inav)
 set(priority)
 set(stack_size 1200)
 set(max_optimization)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wframe-larger-than=3800
 	)
@@ -45,6 +44,5 @@ set(srcs
 	position_estimator_inav_params.c
 	inertial_filter.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	adc.c
 	controls.c
@@ -58,6 +56,5 @@ set(srcs
 	../../lib/rc/st24.c
 	../../lib/rc/sumd.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/sdlog2/CMakeLists.txt
+++ b/src/modules/sdlog2/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main sdlog2)
 set(priority "SCHED_PRIORITY_MAX-30")
 set(stack_size 1200)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wframe-larger-than=1400
 	)
@@ -44,6 +43,5 @@ set(srcs
 	sdlog2.c
 	logbuffer.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/segway/CMakeLists.txt
+++ b/src/modules/segway/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main segway)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	segway_main.cpp
 	BlockSegwayController.cpp
 	params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -38,12 +38,10 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wno-type-limits
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	sensors.cpp
 	sensor_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/systemlib/CMakeLists.txt
+++ b/src/modules/systemlib/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wno-sign-compare
 	)
@@ -58,6 +57,5 @@ set(srcs
 	circuit_breaker.cpp
 	circuit_breaker_params.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/systemlib/mixer/CMakeLists.txt
+++ b/src/modules/systemlib/mixer/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	mixer.cpp
 	mixer_group.cpp
@@ -46,6 +44,5 @@ set(srcs
 	mixer_simple.cpp
 	mixer_load.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/uORB/CMakeLists.txt
+++ b/src/modules/uORB/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main uorb)
 set(priority)
 set(stack_size 2048)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	uORBDevices_nuttx.cpp
 	uORBTest_UnitTest.cpp
 	uORBManager_nuttx.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/uavcan/CMakeLists.txt
+++ b/src/modules/uavcan/CMakeLists.txt
@@ -35,12 +35,9 @@ set(main uavcan)
 set(priority)
 set(stack_size 3200)
 set(max_optimization -O3)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
-set(srcs
-	)
+set(extra_cxxflags)
+set(extra_cflags)
+set(srcs)
 set(includes
 	${LIBUAVCAN_INC}
 	)

--- a/src/modules/unit_test/CMakeLists.txt
+++ b/src/modules/unit_test/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	unit_test.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/vtol_att_control/CMakeLists.txt
+++ b/src/modules/vtol_att_control/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization)
 set(extra_cxxflags
 	-Wno-write-strings
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	vtol_att_control_main.cpp
 	vtol_att_control_params.c
@@ -50,6 +49,5 @@ set(srcs
 	standard_params.c
 	standard.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/common/CMakeLists.txt
+++ b/src/platforms/common/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_getopt.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/nuttx/CMakeLists.txt
+++ b/src/platforms/nuttx/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_nuttx_impl.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/nuttx/px4_layer/CMakeLists.txt
+++ b/src/platforms/nuttx/px4_layer/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_nuttx_tasks.c
 	../../posix/px4_layer/px4_log.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/accelsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/accelsim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main accelsim)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	accelsim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/adcsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/adcsim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main adcsim)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	adcsim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	airspeedsim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/barosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/barosim/CMakeLists.txt
@@ -35,14 +35,11 @@ set(main barosim)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	baro.cpp
 	baro_sim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/gpssim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gpssim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main gpssim)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	gpssim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Weffc++
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	gyrosim.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/drivers/tonealrmsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/tonealrmsim/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main tone_alarm)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	tone_alarm.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/px4_layer/CMakeLists.txt
+++ b/src/platforms/posix/px4_layer/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_posix_impl.cpp
 	px4_posix_tasks.cpp
@@ -46,6 +44,5 @@ set(srcs
 	drv_hrt.c
 	px4_log.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/tests/hello/CMakeLists.txt
+++ b/src/platforms/posix/tests/hello/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main hello)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hello_main.cpp
 	hello_start_posix.cpp
 	hello_example.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/tests/hrt_test/CMakeLists.txt
+++ b/src/platforms/posix/tests/hrt_test/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main hrttest)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hrt_test_main.cpp
 	hrt_test_start_posix.cpp
 	hrt_test.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/tests/muorb/CMakeLists.txt
+++ b/src/platforms/posix/tests/muorb/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main muorb_test)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	muorb_test_main.cpp
 	muorb_test_start_posix.cpp

--- a/src/platforms/posix/tests/vcdev_test/CMakeLists.txt
+++ b/src/platforms/posix/tests/vcdev_test/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main vcdevtest)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	vcdevtest_main.cpp
 	vcdevtest_start_posix.cpp
 	vcdevtest_example.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/tests/wqueue/CMakeLists.txt
+++ b/src/platforms/posix/tests/wqueue/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main wqueue_test)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	wqueue_main.cpp
 	wqueue_start_posix.cpp
 	wqueue_test.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/posix/work_queue/CMakeLists.txt
+++ b/src/platforms/posix/work_queue/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hrt_thread.c
 	hrt_queue.c
@@ -55,6 +53,5 @@ set(srcs
 	sq_addafter.c
 	dq_rem.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	px4_qurt_impl.cpp
 	px4_qurt_tasks.cpp
@@ -47,6 +45,5 @@ set(srcs
 	qurt_stubs.c
 	main.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/qurt/tests/hello/CMakeLists.txt
+++ b/src/platforms/qurt/tests/hello/CMakeLists.txt
@@ -35,15 +35,12 @@ set(main hello)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	hello_main.cpp
 	hello_start_qurt.cpp
 	hello_example.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/platforms/qurt/tests/muorb/CMakeLists.txt
+++ b/src/platforms/qurt/tests/muorb/CMakeLists.txt
@@ -35,10 +35,8 @@ set(main muorb_test)
 set(priority)
 set(stack_size)
 set(max_optimization)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	muorb_test_start_qurt.cpp
 	muorb_test_example.cpp

--- a/src/systemcmds/bl_update/CMakeLists.txt
+++ b/src/systemcmds/bl_update/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main bl_update)
 set(priority)
 set(stack_size 4096)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	bl_update.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/config/CMakeLists.txt
+++ b/src/systemcmds/config/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main config)
 set(priority)
 set(stack_size 4096)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	config.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/dumpfile/CMakeLists.txt
+++ b/src/systemcmds/dumpfile/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main dumpfile)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	dumpfile.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/esc_calib/CMakeLists.txt
+++ b/src/systemcmds/esc_calib/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main esc_calib)
 set(priority)
 set(stack_size 4096)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	esc_calib.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/i2c/CMakeLists.txt
+++ b/src/systemcmds/i2c/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main i2c)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	i2c.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/mixer/CMakeLists.txt
+++ b/src/systemcmds/mixer/CMakeLists.txt
@@ -38,11 +38,9 @@ set(max_optimization -Os)
 set(extra_cxxflags
 	-Wframe-larger-than=2048
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	mixer.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/motor_test/CMakeLists.txt
+++ b/src/systemcmds/motor_test/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main motor_test)
 set(priority)
 set(stack_size 4096)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	motor_test.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/mtd/CMakeLists.txt
+++ b/src/systemcmds/mtd/CMakeLists.txt
@@ -35,8 +35,7 @@ set(main mtd)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
+set(extra_cxxflags)
 set(extra_cflags
 	-Wno-error
 	)
@@ -44,6 +43,5 @@ set(srcs
 	mtd.c
 	24xxxx_mtd.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/nshterm/CMakeLists.txt
+++ b/src/systemcmds/nshterm/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main nshterm)
 set(priority "SCHED_PRIORITY_DEFAULT-30")
 set(stack_size 1500)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	nshterm.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/param/CMakeLists.txt
+++ b/src/systemcmds/param/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main param)
 set(priority)
 set(stack_size 1800)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	param.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/perf/CMakeLists.txt
+++ b/src/systemcmds/perf/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main perf)
 set(priority)
 set(stack_size 1800)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	perf.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/pwm/CMakeLists.txt
+++ b/src/systemcmds/pwm/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main pwm)
 set(priority)
 set(stack_size 1800)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	pwm.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/reboot/CMakeLists.txt
+++ b/src/systemcmds/reboot/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main reboot)
 set(priority)
 set(stack_size 800)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	reboot.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/reflect/CMakeLists.txt
+++ b/src/systemcmds/reflect/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main reflect)
 set(priority)
 set(stack_size)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	reflect.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -38,8 +38,7 @@ set(max_optimization -O0)
 set(extra_cxxflags
 	-Wframe-larger-than=6000
 	)
-set(extra_cflags
-	)
+set(extra_cflags)
 set(srcs
 	test_adc.c
 	test_bson.c
@@ -69,6 +68,5 @@ set(srcs
 	test_mount.c
 	test_eigen.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main top)
 set(priority)
 set(stack_size 1700)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	top.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/topic_listener/CMakeLists.txt
+++ b/src/systemcmds/topic_listener/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main listener)
 set(priority)
 set(stack_size 1800)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	topic_listener.cpp
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/ver/CMakeLists.txt
+++ b/src/systemcmds/ver/CMakeLists.txt
@@ -35,13 +35,10 @@ set(main ver)
 set(priority)
 set(stack_size 1024)
 set(max_optimization -Os)
-set(extra_cxxflags
-	)
-set(extra_cflags
-	)
+set(extra_cxxflags)
+set(extra_cflags)
 set(srcs
 	ver.c
 	)
-set(includes
-	)
+set(includes)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 


### PR DESCRIPTION
Added python script to fix up files with empty set commands in the form:

```
set(foo
    )
```

These become:

```
set(foo)
```

Signed-off-by: Mark Charlebois charlebm@gmail.com
