### PR TITLE
More qurt support

### DIFF
--- a/cmake/px4_impl_qurt.cmake
+++ b/cmake/px4_impl_qurt.cmake
@@ -236,7 +236,7 @@ endfunction()
 #
 #	Usage:
 #		px4_os_prebuild_targets(
-#			OUT <out-list_of_targets>
+#			OUT_MODULES <module-subdir-list>
 #			BOARD <in-string>
 #			)
 #
@@ -244,16 +244,16 @@ endfunction()
 #		BOARD 		: board
 #
 #	Output:
-#		MODULE_LIST	: the updated module list
+#		OUT_MODULES	: the updated module list
 #
 #	Example:
-#		px4_qurt_add_modules(MODULE_LIST module_list BOARD hil)
+#		px4_qurt_add_modules(module_list "hil")
 #
-function(px4_qurt_add_modules out_modules BOARD)
+function(px4_qurt_add_modules OUT_MODULES BOARD)
 	include(config-qurt-${BOARD})
 	set(config_modules)
 	px4_set_config_modules(config_modules)
-	set(${out_modules} ${out_modules} ${config_modules} PARENT_SCOPE)
+	set(${OUT_MODULES} ${${OUT_MODULES}} ${config_modules} PARENT_SCOPE)
 endfunction()
 
 # vim: set noet fenc=utf-8 ff=unix nowrap:

--- a/cmake/px4_impl_qurt.cmake
+++ b/cmake/px4_impl_qurt.cmake
@@ -98,13 +98,13 @@ function(px4_qurt_generate_builtin_commands)
 		endforeach()
 		if (MAIN)
 			set(builtin_apps_string
-				"${builtin_apps_string}\t{\"${MAIN}\", ${PRIORITY}, ${STACK}, ${MAIN}_main},\n")
+				"${builtin_apps_string}\tapps[\"${MAIN}\"] = ${MAIN}_main;\n")
 			set(builtin_apps_decl_string
 				"${builtin_apps_decl_string}extern int ${MAIN}_main(int argc, char *argv[]);\n")
 			math(EXPR command_count "${command_count}+1")
 		endif()
 	endforeach()
-	configure_file(${CMAKE_SOURCE_DIR}/cmake/builtin_commands.c.cmake
+	configure_file(${CMAKE_SOURCE_DIR}/cmake/qurt/builtin_commands.cpp_stub
 		${OUT})
 endfunction()
 
@@ -226,6 +226,7 @@ function(px4_os_prebuild_targets)
 			ONE_VALUE OUT BOARD THREADS
 			REQUIRED OUT BOARD
 			ARGN ${ARGN})
+	add_custom_target(${OUT})
 endfunction()
 
 #=============================================================================

--- a/cmake/qurt/builtin_commands.cpp_stub
+++ b/cmake/qurt/builtin_commands.cpp_stub
@@ -1,0 +1,84 @@
+/* builtin command list - automatically generated, do not edit */
+#include <string>
+#include <map>
+#include <stdio.h>
+
+#include <px4_tasks.h>
+#include <px4_posix.h>
+#include <px4_log.h>
+#include <stdlib.h>
+
+using namespace std;
+
+extern void px4_show_devices(void);
+
+extern "C" {
+${builtin_apps_decl_string}
+static int shutdown_main(int argc, char *argv[]);
+static int list_tasks_main(int argc, char *argv[]);
+static int list_files_main(int argc, char *argv[]);
+static int list_devices_main(int argc, char *argv[]);
+static int list_topics_main(int argc, char *argv[]);
+static int sleep_main(int argc, char *argv[]);
+}
+
+
+void init_app_map(map<string,px4_main_t> &apps)
+{
+${builtin_apps_string}
+	apps["shutdown"] = shutdown_main;
+	apps["list_tasks"] = list_tasks_main;
+	apps["list_files"] = list_files_main;
+	apps["list_devices"] = list_devices_main;
+	apps["list_topics"] = list_topics_main;
+	apps["sleep"] = sleep_main;
+}
+
+void list_builtins(map<string,px4_main_t> &apps)
+{
+	printf("Builtin Commands:\\n");
+	for (map<string,px4_main_t>::iterator it=apps.begin(); it!=apps.end(); ++it)
+		printf("\\t%s\\n", (it->first).c_str());
+}
+
+static int shutdown_main(int argc, char *argv[])
+{
+	printf("Shutting down\\n");
+	exit(0);
+}
+
+static int list_tasks_main(int argc, char *argv[])
+{
+	px4_show_tasks();
+	return 0;
+}
+
+static int list_devices_main(int argc, char *argv[])
+{
+	px4_show_devices();
+	return 0;
+}
+
+static int list_topics_main(int argc, char *argv[])
+{
+	px4_show_topics();
+	return 0;
+}
+static int list_files_main(int argc, char *argv[])
+{
+	px4_show_files();
+	return 0;
+}
+static int sleep_main(int argc, char *argv[])
+{
+        if (argc != 2) {
+           PX4_WARN( "Usage: sleep <seconds>" );
+           return 1;
+        }
+
+        unsigned long usecs = ( (unsigned long) atol( argv[1] ) ) * 1000 * 1000;
+        PX4_WARN("Sleeping for %s, %ld",argv[1],usecs);
+        usleep( usecs );
+        return 0;
+}
+

--- a/cmake/qurt/configs/config-qurt-hil.cmake
+++ b/cmake/qurt/configs/config-qurt-hil.cmake
@@ -77,7 +77,7 @@ function(px4_set_config_modules out_module_list)
 	#
 	# sources for muorb over fastrpc
 	#
-		modules/muorb/adsp/
+		modules/muorb/adsp
 		)
 	message(STATUS "modules: ${config_module_list}")
 	set(${out_module_list} ${config_module_list} PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,11 +75,10 @@ elseif(${OS} STREQUAL "qurt")
 	px4_qurt_add_modules(module_list ${BOARD})
 	message(STATUS "module list: ${module_list}")
 
-	px4_qurt_generate_builtin_commands(
-		OUT builtin_commands.c
-		MODULE_LIST ${module_list})
-
-	add_executable(mainapp builtin_commands.c)
+	foreach(directory ${module_list})
+		message(STATUS "directory: ${directory}")
+        	add_subdirectory(${directory} EXCLUDE_FROM_ALL)
+	endforeach()
 endif()
 
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,11 @@ if (${OS} STREQUAL "nuttx")
 		ROOT ${CMAKE_SOURCE_DIR}/ROMFS/px4fmu_common)
 
 elseif(${OS} STREQUAL "qurt")
+	
+	set(V_ARCH v5)
+	set(HEXAGON_TOOLS_ROOT /opt/6.4.03)
+	set(TOOLSLIB 
+		${HEXAGON_TOOLS_ROOT}/dinkumware/lib/${V_ARCH}/G0)
 	set(module_dir_list)
 	set(module_list)
 	px4_qurt_add_modules(module_dir_list ${BOARD})
@@ -98,12 +103,13 @@ elseif(${OS} STREQUAL "qurt")
         set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
         set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
-	add_executable(main builtin_commands.cpp)
-	target_link_libraries(main
-		-Wl,--start-group
+	add_executable(mainapp builtin_commands.cpp)
+	target_link_libraries(mainapp
+		-Wl,--whole-archive
 		${module_list}
-		apps nuttx nosys m gcc
-		-Wl,--end-group)
+		m
+		-Wl,--no-whole-archive
+		-Wl,${TOOLSLIB}/pic/libstdc++.a)
 endif()
 
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,23 @@
 # executable
 #
 
-if (${OS} STREQUAL "nuttx")
+function(px4_mangle_name dirname newname)
+	set(tmp)
+	string(REPLACE "/" "__" tmp ${dirname})
+	set(${newname} ${tmp} PARENT_SCOPE)
+endfunction()
 
-	#=============================================================================
-	# module subdirectories, need to include first
-	#
-	add_subdirectory(./lib)
-	add_subdirectory(./drivers)
-	add_subdirectory(./platforms)
-	add_subdirectory(./systemcmds)
-	add_subdirectory(./examples)
-	add_subdirectory(./modules)
+#=============================================================================
+# module subdirectories, need to include first
+#
+add_subdirectory(./lib)
+add_subdirectory(./drivers)
+add_subdirectory(./platforms)
+add_subdirectory(./systemcmds)
+add_subdirectory(./examples)
+add_subdirectory(./modules)
+
+if (${OS} STREQUAL "nuttx")
 
 	# a list of modules that will be linked to main
 	set(module_list)
@@ -71,14 +77,33 @@ if (${OS} STREQUAL "nuttx")
 		ROOT ${CMAKE_SOURCE_DIR}/ROMFS/px4fmu_common)
 
 elseif(${OS} STREQUAL "qurt")
+	set(module_dir_list)
 	set(module_list)
-	px4_qurt_add_modules(module_list ${BOARD})
-	message(STATUS "module list: ${module_list}")
+	px4_qurt_add_modules(module_dir_list ${BOARD})
+	message(STATUS "module list: ${module_dir_list}")
 
-	foreach(directory ${module_list})
+	foreach(directory ${module_dir_list})
 		message(STATUS "directory: ${directory}")
-        	add_subdirectory(${directory} EXCLUDE_FROM_ALL)
+		px4_mangle_name(${directory} mangled_name)
+		list(APPEND module_list
+			${mangled_name})
 	endforeach()
+	px4_qurt_generate_builtin_commands(
+		OUT builtin_commands.cpp
+		MODULE_LIST ${module_list})
+
+	# FIXME @jgoppert - how to work around issues like this?
+        # Without changing global variables?
+        # Clear -rdynamic flag which fails for hexagon
+        set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+        set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
+	add_executable(main builtin_commands.cpp)
+	target_link_libraries(main
+		-Wl,--start-group
+		${module_list}
+		apps nuttx nosys m gcc
+		-Wl,--end-group)
 endif()
 
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(directories
 	./boards/px4io-v1
 	./boards/px4fmu-v1
 	./boards/aerocore
+	./boards/sitl
 	./mpu6000
 	./gimbal
 	./camera_trigger

--- a/src/modules/muorb/adsp/CMakeLists.txt
+++ b/src/modules/muorb/adsp/CMakeLists.txt
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+include_directories("../../uORB")
+
 px4_add_module(
 	MODULE modules__muorb__adsp
 	COMPILE_FLAGS

--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -31,7 +31,7 @@
  *
  ****************************************************************************/
 #include "px4muorb.hpp"
-#include "qurt.h"
+//#include "qurt.h"
 #include "uORBFastRpcChannel.hpp"
 #include "uORBManager.hpp"
 
@@ -44,12 +44,11 @@
 #include "uORB/topics/sensor_combined.h"
 #include "uORB.h"
 
-#include "HAP_power.h"
-
 #define _ENABLE_MUORB 1
 
 extern "C" {
 int dspal_main(int argc, const char *argv[]);
+void HAP_power_request(int a, int b, int c);
 };
 
 

--- a/src/modules/systemlib/perf_counter.c
+++ b/src/modules/systemlib/perf_counter.c
@@ -47,6 +47,9 @@
 
 #ifdef __PX4_QURT
 #define dprintf(...)
+#define ddeclare(...)
+#else
+#define ddeclare(...) __VA_ARGS_
 #endif
 
 /**
@@ -417,8 +420,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 		break;
 
 	case PC_ELAPSED: {
-			struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
-			float rms = sqrtf(pce->M2 / (pce->event_count - 1));
+			ddeclare(struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;)
+			ddeclare(float rms = sqrtf(pce->M2 / (pce->event_count - 1));)
 			dprintf(fd, "%s: %llu events, %llu overruns, %lluus elapsed, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 				handle->name,
 				(unsigned long long)pce->event_count,
@@ -432,8 +435,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 		}
 
 	case PC_INTERVAL: {
-			struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
-			float rms = sqrtf(pci->M2 / (pci->event_count - 1));
+			ddeclare(struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;)
+			ddeclare(float rms = sqrtf(pci->M2 / (pci->event_count - 1));)
 
 			dprintf(fd, "%s: %llu events, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 				handle->name,

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -70,33 +70,33 @@ static inline void do_nothing(int level, ...)
 /****************************************************************************
  * Messages that should never be filtered or compiled out
  ****************************************************************************/
-#define PX4_LOG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_INFO(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_LOG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_INFO(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #if defined(TRACE_BUILD)
 /****************************************************************************
  * Extremely Verbose settings for a Trace build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #elif defined(DEBUG_BUILD)
 /****************************************************************************
  * Verbose settings for a Debug build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN, __FILENAME__, __LINE__,  FMT, ##__VA_ARGS__)
-#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN, __FILE__, __LINE__,  FMT, ##__VA_ARGS__)
+#define PX4_DEBUG(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_DEBUG, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 
 #elif defined(RELEASE_BUILD)
 /****************************************************************************
  * Non-verbose settings for a Release build to minimize strings in build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 #define PX4_WARN(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_WARN, FMT, ##__VA_ARGS__)
 #define PX4_DEBUG(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_DEBUG, FMT, ##__VA_ARGS__)
 
@@ -104,14 +104,14 @@ static inline void do_nothing(int level, ...)
 /****************************************************************************
  * Medium verbose settings for a default build
  ****************************************************************************/
-#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILENAME__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_PANIC(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_PANIC, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	qurt_log(_PX4_LOG_LEVEL_ERROR, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_WARN,  __FILE__, __LINE__, FMT, ##__VA_ARGS__)
 #define PX4_DEBUG(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_DEBUG, FMT, ##__VA_ARGS__)
 
 #endif
-#define PX4_LOG_NAMED(name, FMT, ...) 	qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, "%s " FMT, name, ##__VA_ARGS__)
-#define PX4_LOG_NAMED_COND(name, cond, FMT, ...) if( cond ) qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILENAME__, __LINE__, "%s " FMT, name,  ##__VA_ARGS__)
+#define PX4_LOG_NAMED(name, FMT, ...) 	qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, "%s " FMT, name, ##__VA_ARGS__)
+#define PX4_LOG_NAMED_COND(name, cond, FMT, ...) if( cond ) qurt_log( _PX4_LOG_LEVEL_ALWAYS, __FILE__, __LINE__, "%s " FMT, name,  ##__VA_ARGS__)
 
 #else
 

--- a/src/platforms/qurt/px4_layer/qurt_stubs.c
+++ b/src/platforms/qurt/px4_layer/qurt_stubs.c
@@ -60,6 +60,7 @@ void _Parse_csd( void )
    block_indefinite(); 
 }
 
+#if 0
 void _Locksyslock( int x )
 {
    PX4_WARN( "Error: Calling unresolved symbol stub[%s]", __FUNCTION__ );
@@ -70,7 +71,7 @@ void _Unlocksyslock( int x )
 {
    PX4_WARN( "Error: Calling unresolved symbol stub[%s]", __FUNCTION__ );
    block_indefinite(); 
-}
+#endif}
 
 void _Valbytes( void )
 {


### PR DESCRIPTION
The current approach of distributing submodule inclusion logic makes
evert parent dir need to know about all build targets.

This approach goes back to the previous way of centralizing the build
dirs in a single file.

Signed-off-by: Mark Charlebois charlebm@gmail.com
