### PR TITLE
cmake: Added dspal and eigen32 to top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,12 +183,11 @@ px4_add_git_submodule(TARGET git_gencpp PATH "Tools/gencpp")
 px4_add_git_submodule(TARGET git_mavlink PATH "mavlink/include/mavlink/v1.0")
 px4_add_git_submodule(TARGET git_gtest PATH "unittets/gtest")
 px4_add_git_submodule(TARGET git_uavcan PATH "src/lib/uavcan")
-if (NOT ${OS} STREQUAL "qurt")
-	px4_add_git_submodule(TARGET git_eigen PATH "src/lib/eigen")
-endif()
-if(${OS} STREQUAL "nuttx")
-	px4_add_git_submodule(TARGET git_nuttx PATH "NuttX")
-endif()
+px4_add_git_submodule(TARGET git_eigen PATH "src/lib/eigen")
+px4_add_git_submodule(TARGET git_nuttx PATH "NuttX")
+px4_add_git_submodule(TARGET git_eigen32 PATH "src/lib/eigen-3.2")
+px4_add_git_submodule(TARGET git_dspal PATH "src/lib/dspal")
+
 add_custom_target(submodule_clean
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	COMMAND git submodule deinit -f .

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -52,9 +52,6 @@
 include(common/px4_base)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/qurt)
 
-px4_add_git_submodule(TARGET git_dspal PATH "src/lib/dspal")
-px4_add_git_submodule(TARGET git_eigen32 PATH "src/lib/eigen-3.2")
-
 #=============================================================================
 #
 #	px4_qurt_generate_builtin_commands


### PR DESCRIPTION
Relying on inclusion of git_eigen32 and git_dspal targets to trigger
the submodule init and update

Signed-off-by: Mark Charlebois charlebm@gmail.com
