### PR TITLE
Multi subscription for range finders

### DIFF
--- a/src/drivers/ll40ls/LidarLite.h
+++ b/src/drivers/ll40ls/LidarLite.h
@@ -45,7 +45,7 @@
 
 /* Device limits */
 #define LL40LS_MIN_DISTANCE (0.00f)
-#define LL40LS_MAX_DISTANCE (60.00f)
+#define LL40LS_MAX_DISTANCE (40.00f)
 
 // normal conversion wait time
 #define LL40LS_CONVERSION_INTERVAL 50*1000UL /* 50ms */

--- a/src/drivers/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/ll40ls/LidarLiteI2C.cpp
@@ -126,7 +126,7 @@ int LidarLiteI2C::init()
 
 	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	if (_class_instance == CLASS_DEVICE_PRIMARY) {
+	if (_class_instance >= 0) {
 		/* get a publish handle on the range finder topic */
 		struct distance_sensor_s ds_report;
 		measure();

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -108,13 +108,13 @@ int LidarLitePWM::init()
 
 	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	if (_class_instance == CLASS_DEVICE_PRIMARY) {
+	if (_class_instance >= 0) {
 		/* get a publish handle on the distance_sensor topic */
 		struct distance_sensor_s ds_report;
 		measure();
 		_reports->get(&ds_report);
 		_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-							     &_orb_class_instance, ORB_PRIO_LOW);
+							     &_orb_class_instance, ORB_PRIO_DEFAULT);
 
 		if (_distance_sensor_topic == nullptr) {
 			DEVICE_DEBUG("failed to create distance_sensor object. Did you start uOrb?");

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -269,7 +269,7 @@ MB12XX::init()
 
 	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	if (_class_instance == CLASS_DEVICE_PRIMARY) {
+	if (_class_instance >= 0) {
 		/* get a publish handle on the range finder topic */
 		struct distance_sensor_s ds_report = {};
 

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -237,12 +237,12 @@ PX4FLOW::init()
 
 	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	if (_class_instance == CLASS_DEVICE_PRIMARY) {
+	if (_class_instance >= 0) {
 		/* get a publish handle on the range finder topic */
 		struct distance_sensor_s ds_report = {};
 
 		_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-							     &_orb_class_instance, ORB_PRIO_HIGH);
+							     &_orb_class_instance, ORB_PRIO_LOW);
 
 		if (_distance_sensor_topic == nullptr) {
 			DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -293,7 +293,7 @@ SF0X::init()
 
 		_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-		if (_class_instance == CLASS_DEVICE_PRIMARY) {
+		if (_class_instance >= 0) {
 			/* get a publish handle on the range finder topic */
 			struct distance_sensor_s ds_report = {};
 

--- a/src/drivers/trone/trone.cpp
+++ b/src/drivers/trone/trone.cpp
@@ -294,7 +294,7 @@ TRONE::init()
 
 	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	if (_class_instance == CLASS_DEVICE_PRIMARY) {
+	if (_class_instance >= 0) {
 		/* get a publish handle on the range finder topic */
 		struct distance_sensor_s ds_report;
 		measure();

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -160,13 +160,14 @@ private:
 	uORB::Subscription<vehicle_attitude_setpoint_s> _sub_att_sp;
 	uORB::Subscription<optical_flow_s> _sub_flow;
 	uORB::Subscription<sensor_combined_s> _sub_sensor;
-	uORB::Subscription<distance_sensor_s> _sub_distance;
 	uORB::Subscription<parameter_update_s> _sub_param_update;
 	uORB::Subscription<manual_control_setpoint_s> _sub_manual;
 	uORB::Subscription<home_position_s> _sub_home;
 	uORB::Subscription<vehicle_gps_position_s> _sub_gps;
 	uORB::Subscription<vision_position_estimate_s> _sub_vision_pos;
 	uORB::Subscription<att_pos_mocap_s> _sub_mocap;
+	uORB::Subscription<distance_sensor_s> * _distance_subs[ORB_MULTI_MAX_INSTANCES];
+	uORB::Subscription<distance_sensor_s> * _sub_distance;
 
 	// publications
 	uORB::Publication<vehicle_local_position_s> _pub_lpos;
@@ -220,6 +221,7 @@ private:
 	uint64_t _time_last_vision_p;
 	uint64_t _time_last_mocap;
 	int 	 _mavlink_fd;
+	int 	 _distance_sensor_prio;
 
 	// initialization flags
 	bool _baroInitialized;
@@ -229,6 +231,7 @@ private:
 	bool _flowInitialized;
 	bool _visionPosInitialized;
 	bool _mocapInitialized;
+	bool _distInitialized;
 
 	// init counts
 	int _baroInitCount;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -454,7 +454,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 
 	if (_distance_sensor_pub == nullptr) {
 		_distance_sensor_pub = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-								     &_orb_class_instance, ORB_PRIO_HIGH);
+								     &_orb_class_instance, ORB_PRIO_DEFAULT); // XXX prio ok?
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_pub, &d);
 	}
@@ -568,7 +568,7 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 
 	if (_distance_sensor_pub == nullptr) {
 		_distance_sensor_pub = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-								     &_orb_class_instance, ORB_PRIO_HIGH);
+								     &_orb_class_instance, ORB_PRIO_DEFAULT); // XXX prio ok?
 
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_pub, &d);

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -87,13 +87,18 @@ public:
 // accessors
 	const struct orb_metadata *getMeta() { return _meta; }
 	int getHandle() { return _handle; }
+	int getPriority() { return _priority; }
+	int getInstance() { return _instance; }
 protected:
 // accessors
 	void setHandle(int handle) { _handle = handle; }
+	bool subscribe();
 // attributes
 	const struct orb_metadata *_meta;
 	int _instance;
 	int _handle;
+	int _priority;
+	int _interval;
 private:
 	// disallow copy
 	SubscriptionBase(const SubscriptionBase &other);


### PR DESCRIPTION
**do not merge**

Hi @jgoppert 
I've been talking @mhkabir about lidar integration and wanted to give him a hand with this multi subscription thing. The change is more involving than I expected ;)

There are a few things to point out so I'm opening this PR for exactly that. And for Kabir to take over :)
- First, the main change that was needed to get multiple distance sensors publishing at the same time is in their drivers. Until now only the first recognized range finder advertised itself. I also updated the various priority settings according to what I know about the sensors reliability.
- To be able to choose the range finder based on it's priority it needs "lazy subscriptions" (flow and lidar drivers are started after the estimator). I modified the subscription wrappers to check on subscription existence before they give updates and ready priority.
- The estimator now only uses the distance sensor with the highest priority.

I'm not sure if the last item is correct or wanted. IMHO if I have the flow and a lidar attached I only want to use the distance reading from the lidar. But I guess there are other use-cases where it's different.

What do you think?

**NOTE**: I have only bench tested this to verify that it recognizes multiple distance sensors. Otherwise this is not tested.

Furthermore, I did not yet update EKF. That will of course be easy once this looks good. The priority handling that I put in there could be generalized and used in both estimators afterwards. In case your wondering, I believe this is independent from https://github.com/PX4/Firmware/pull/2818 as the sensor voting and priority handling for gyro/accel/baro is quite specific to those types of sensors.
